### PR TITLE
switch to distubejs/ytdl-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.52.1",
-    "ytdl-core": "git+https://github.com/khlevon/node-ytdl-core.git#v4.11.4-patch.2",
+    "ytdl-core": "git+https://github.com/distubejs/ytdl-core.git",
     "zod": "3.23.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Potential workaround for ongoing 403 errors resulting from [upstream ytdl-core issue](https://github.com/fent/node-ytdl-core/issues/1295).